### PR TITLE
1.21.6 port and suggested option to prevent all deaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Protect tamed mobs from PvP.
 
 ## Configuration
 - `prevent_pet_damage`: Global toggle for the mod
+- `prevent_pet_death`: Decides whether pets will be able to die under any circumstances
 - `prevent_pet_attack`: Decides whether pets will attack players
-- `allow_owner_damage`: Decides whether owners should be able to damage their own pets
+- `allow_owner_damage`: Decides whether owners should be able to damage (and kill!) their own pets regardless of other rules
 - `ignore_creative`: Decides whether creative players can damage pets regardless of other rules
 
 *The configuration (`config/petprotect.json`) is loaded on server start and there is currently no way to change or reload options without restarting.*

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Protect tamed mobs from PvP.
 ## Configuration
 - `prevent_pet_damage`: Global toggle for the mod
 - `prevent_pet_death`: Decides whether pets will be able to die under any circumstances
+- `apply_totem_effects`: Decides whether Totem of Undying effects will be applied when preventing the death of a pet
 - `prevent_pet_attack`: Decides whether pets will attack players
 - `allow_owner_damage`: Decides whether owners should be able to damage (and kill!) their own pets regardless of other rules
 - `ignore_creative`: Decides whether creative players can damage pets regardless of other rules

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10.1'
+    id 'fabric-loom' version '1.10-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
-# check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.10
+# check these on https://fabricmc.net/develop/
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
+loader_version=0.16.14
 
 # Mod Properties
 mod_version=1.1.1
@@ -12,7 +12,5 @@ maven_group=lol.sylvie
 archives_base_name=petprotect
 
 # Dependencies
-# check this on https://modmuss50.me/fabric.html
-
-# Fabric API
-fabric_version=0.119.6+1.21.5
+# Fabric API - https://fabricmc.net/develop/
+fabric_version=0.127.1+1.21.6

--- a/src/main/java/lol/sylvie/petprotect/PetProtect.java
+++ b/src/main/java/lol/sylvie/petprotect/PetProtect.java
@@ -2,9 +2,15 @@ package lol.sylvie.petprotect;
 
 import lol.sylvie.petprotect.config.ConfigInstance;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.component.type.DeathProtectionComponent;
+import net.minecraft.entity.EntityStatuses;
 import net.minecraft.entity.passive.TameableEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +37,22 @@ public class PetProtect implements ModInitializer {
                 }
             }
             return ActionResult.PASS;
+        });
+
+        ServerLivingEntityEvents.ALLOW_DEATH.register((entity, damageSource, damageAmount) -> {
+            if (!config.preventPetDamage() || !config.preventPetDeath()) return true;
+            if (damageSource.getAttacker() instanceof PlayerEntity player && ((config.shouldIgnoreCreative() && player.isCreative()) || player.isSpectator())) return true;
+            if (entity instanceof TameableEntity tameable) {
+                if (tameable.getOwnerReference() == null) return true; // Mob is not tamed
+                if (!(damageSource.getAttacker() instanceof PlayerEntity player && tameable.isOwner(player) && config.allowOwnerDamage())) {
+                    // we're not allowing this death: reset health to full, and apply a Totem of Undying effect
+                    entity.setHealth(entity.getMaxHealth());
+                    DeathProtectionComponent.TOTEM_OF_UNDYING.applyDeathEffects(new ItemStack(Items.TOTEM_OF_UNDYING), entity);
+                    entity.getWorld().sendEntityStatus(entity, EntityStatuses.USE_TOTEM_OF_UNDYING);
+                    return false;
+                }
+            }
+            return true;
         });
     }
 }

--- a/src/main/java/lol/sylvie/petprotect/PetProtect.java
+++ b/src/main/java/lol/sylvie/petprotect/PetProtect.java
@@ -41,14 +41,16 @@ public class PetProtect implements ModInitializer {
 
         ServerLivingEntityEvents.ALLOW_DEATH.register((entity, damageSource, damageAmount) -> {
             if (!config.preventPetDamage() || !config.preventPetDeath()) return true;
-            if (damageSource.getAttacker() instanceof PlayerEntity player && ((config.shouldIgnoreCreative() && player.isCreative()) || player.isSpectator())) return true;
+            if (damageSource.isSourceCreativePlayer() && config.shouldIgnoreCreative()) return true;
             if (entity instanceof TameableEntity tameable) {
                 if (tameable.getOwnerReference() == null) return true; // Mob is not tamed
                 if (!(damageSource.getAttacker() instanceof PlayerEntity player && tameable.isOwner(player) && config.allowOwnerDamage())) {
-                    // we're not allowing this death: reset health to full, and apply a Totem of Undying effect
+                    // we're not allowing this death: reset health to full
                     entity.setHealth(entity.getMaxHealth());
-                    DeathProtectionComponent.TOTEM_OF_UNDYING.applyDeathEffects(new ItemStack(Items.TOTEM_OF_UNDYING), entity);
-                    entity.getWorld().sendEntityStatus(entity, EntityStatuses.USE_TOTEM_OF_UNDYING);
+                    if (config.applyTotemEffects()) {
+                        DeathProtectionComponent.TOTEM_OF_UNDYING.applyDeathEffects(new ItemStack(Items.TOTEM_OF_UNDYING), entity);
+                        entity.getWorld().sendEntityStatus(entity, EntityStatuses.USE_TOTEM_OF_UNDYING);
+                    }
                     return false;
                 }
             }

--- a/src/main/java/lol/sylvie/petprotect/config/ConfigInstance.java
+++ b/src/main/java/lol/sylvie/petprotect/config/ConfigInstance.java
@@ -19,6 +19,9 @@ public class ConfigInstance {
     @SerializedName("prevent_pet_death")
     boolean preventPetDeath = true;
 
+    @SerializedName("apply_totem_effects")
+    boolean applyTotemEffects = false;
+
     @SerializedName("prevent_pet_attack")
     boolean preventPetAttack = true;
 
@@ -53,6 +56,10 @@ public class ConfigInstance {
 
     public boolean preventPetDeath() {
         return preventPetDeath;
+    }
+
+    public boolean applyTotemEffects() {
+        return applyTotemEffects;
     }
 
     public boolean preventPetAttack() {

--- a/src/main/java/lol/sylvie/petprotect/config/ConfigInstance.java
+++ b/src/main/java/lol/sylvie/petprotect/config/ConfigInstance.java
@@ -16,6 +16,9 @@ public class ConfigInstance {
     @SerializedName("prevent_pet_damage")
     boolean preventPetDamage = true;
 
+    @SerializedName("prevent_pet_death")
+    boolean preventPetDeath = true;
+
     @SerializedName("prevent_pet_attack")
     boolean preventPetAttack = true;
 
@@ -46,6 +49,10 @@ public class ConfigInstance {
 
     public boolean preventPetDamage() {
         return preventPetDamage;
+    }
+
+    public boolean preventPetDeath() {
+        return preventPetDeath;
     }
 
     public boolean preventPetAttack() {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,6 @@
   "depends": {
     "fabricloader": ">=${loader_version}",
     "fabric": "*",
-    "minecraft": ["1.21.5"]
+    "minecraft": ["1.21.6"]
   }
 }


### PR DESCRIPTION
- Port to 1.21.6 (just updated dependencies, tested and seems to work as expected)
- My implementation of my suggested feature which optionally prevents all pet deaths from any cause (subject to other rules, such as creative players or pet owners)
  - Somewhat opinionated in it's current form, it creates Totem of Undying particles and gives those potion effects when saving a pet from death